### PR TITLE
Fixing the link of the post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GeoNode Summit 2018
 
 ### About
-The website for GeoNode Summit 2018. It is based on project Zeppelin.
+The website for GeoNode Summit 2019. It is based on project Zeppelin.
 
 Project is built on top of [Jekyll](http://jekyllrb.com/) - simple, blog-aware, static site generator. Jekyll also happens to be the engine behind GitHub Pages, which means you can use Jekyll to host your website from GitHub’s servers for free. [Learn more about Jekyll](http://jekyllrb.com/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GeoNode Summit 2018
+# GeoNode Summit 2019
 
 ### About
 The website for GeoNode Summit 2019. It is based on project Zeppelin.

--- a/_posts/2019-04-19-call-for-speakers.markdown
+++ b/_posts/2019-04-19-call-for-speakers.markdown
@@ -17,7 +17,7 @@ GeoNode Summit 2019 will be held from June 11 to 13 in Viareggio, Italy. If you 
 If you belong to one of those groups you are cordially invited to submit a talk proposal (or a number of proposals).
 
 
-#### Please submit your proposals [here](http://bit.ly/2rzWEeb).
+#### Please submit your proposals [here](https://docs.google.com/forms/d/e/1FAIpQLScZO5EjSZXTShA6iPlpcwBCN-RKb9FNGQkGvWQq9BNwsi4sWw/viewform).
 __Deadline__ is May 20 2019
 
 __Please note:__ There is no guarantee that a submission will be put onto the conference agenda!<br/>


### PR DESCRIPTION
Fixed wrong link in the `call-for-speakers` post.
Readme file update (2019).